### PR TITLE
Fix `AxmlParser.getNamespaceUri` always returning null

### DIFF
--- a/src/main/java/pxb/android/axml/AxmlParser.java
+++ b/src/main/java/pxb/android/axml/AxmlParser.java
@@ -163,7 +163,7 @@ public class AxmlParser implements ResConst {
 	}
 
 	public String getNamespaceUri() {
-		if (nsIdx < 0 && nsIdx >= strings.length) {
+		if (nsIdx >= 0 && nsIdx < strings.length) {
 			return strings[nsIdx];
 		}
 		return null;


### PR DESCRIPTION
See https://github.com/Sable/axml/issues/13